### PR TITLE
ARCH-285: Get zipkin integration working well over http2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Changelog for the gruf gem. This includes internal history before the gem was made.
+Changelog for the gruf-zipkin gem.
 
-h3. 0.9.0
+h3. 0.10.0
 
 - Initial public release

--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 source 'https://rubygems.org'
 
+gem 'gruf', git: 'git@github.com:bigcommerce/gruf', tag: 'v0.11.5'
+
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/bigcommerce/gruf-zipkin.svg?token=D3Cc4LCF9BgpUx4dpPpv&branch=master)](https://travis-ci.com/bigcommerce/gruf-zipkin)
 
-Adds Zipkin tracing support for [gruf](https://github.com/bigcommerce/gruf) 0.11.3 or later.
+Adds Zipkin tracing support for [gruf](https://github.com/bigcommerce/gruf) 0.11.5 or later.
 
 ## Installation
 
@@ -10,16 +10,38 @@ Adds Zipkin tracing support for [gruf](https://github.com/bigcommerce/gruf) 0.11
 gem 'gruf-zipkin'
 ```
 
-Then in an initializer or before use:
+Then in an initializer or before use, after loading gruf:
 
 ```ruby
+require 'zipkin-tracer'
 require 'gruf/zipkin'
 
+# Set it in the Rails config, or alternatively make this just a hash if not using Rails
+Rails.application.config.zipkin_tracer = {
+  service_name: 'my-service',
+  service_port: 1234,
+  json_api_host: 'zipkin.mydomain.com',
+  sampled_as_boolean: false,
+  sample_rate: 1.0 # 0.0 to 1.0, where 1.0 => 100% of requests 
+}
+Gruf.configure do |c|
+  c.hook_options = {
+    zipkin: Rails.application.config.zipkin_tracer
+  }
+end
 Gruf::Hooks::Registry.add(:zipkin, Gruf::Zipkin::Hook)
 ```
 
 This assumes you have Zipkin already setup in your Ruby/Rails app via the installation 
 instructions in the [zipkin-tracer](https://github.com/openzipkin/zipkin-ruby) gem.
+
+### Rails/Rack Tracing
+
+Add this to config.ru, if using above configuration:
+ 
+```ruby
+use ZipkinTracer::RackHandler, Rails.application.config.zipkin_tracer
+```
 
 ## Configuration
 
@@ -30,8 +52,8 @@ Gruf.configure do |c|
   c.hook_options = {
     zipkin: {
       span_prefix: 'myapp',
-    }    
-  }  
+    }
+  }
 end
 ```
 

--- a/lib/gruf/zipkin.rb
+++ b/lib/gruf/zipkin.rb
@@ -28,6 +28,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 require 'zipkin-tracer'
 require_relative 'zipkin/version'
+require_relative 'zipkin/headers'
+require_relative 'zipkin/method'
+require_relative 'zipkin/trace'
 require_relative 'zipkin/hook'
 
 module Gruf

--- a/lib/gruf/zipkin/headers.rb
+++ b/lib/gruf/zipkin/headers.rb
@@ -1,0 +1,42 @@
+module Gruf
+  module Zipkin
+    ##
+    # Abstraction accessor class for B3 propagation headers across GRPC ActiveCall objects
+    #
+    class Headers
+      attr_reader :active_call
+
+      ##
+      # @property [Hash<Symbol|Array<String>>] Hash mapping of metadata keys
+      #
+      ZIPKIN_KEYS = {
+          parent_span_id: %w(x-b3-parentspanid X-B3-ParentSpanId HTTP_X_B3_PARENTSPANID),
+          span_id: %w(x-b3-spanid X-B3-SpanId HTTP_X_B3_SPANID),
+          trace_id: %w(x-b3-traceid X-B3-TraceId HTTP_X_B3_TRACEID),
+          sampled: %w(x-b3-sampled X-B3-Sampled HTTP_X_B3_SAMPLED),
+          flags: %w(x-b3-flags X-B3-Flags HTTP_X_B3_FLAGS)
+      }.freeze
+
+      ##
+      # @param [GRPC::ActiveCall] active_call
+      #
+      def initialize(active_call)
+        @active_call = active_call
+      end
+
+      ##
+      # Return a B3 propagation header if present
+      #
+      # @param [Symbol] key
+      # @return [String|NilClass]
+      #
+      def value(key)
+        return nil unless ZIPKIN_KEYS.key?(key)
+        ZIPKIN_KEYS[key].each do |k|
+          return @active_call.metadata[k] if @active_call.metadata.key?(k)
+        end
+        nil
+      end
+    end
+  end
+end

--- a/lib/gruf/zipkin/method.rb
+++ b/lib/gruf/zipkin/method.rb
@@ -1,0 +1,35 @@
+module Gruf
+  module Zipkin
+    ##
+    # Represents a Gruf gRPC method call
+    #
+    class Method
+      attr_reader :active_call, :signature, :request
+
+      ##
+      # @param [GRPC::ActiveCall] active_call The gRPC ActiveCall object for this method
+      # @param [String|Symbol] signature The method signature being called
+      # @param [Object] request The gRPC request object being used
+      #
+      def initialize(active_call, signature, request)
+        @active_call = active_call
+        @signature = signature.to_s.gsub('_without_intercept', '')
+        @request = request
+      end
+
+      ##
+      # @return [Gruf::Zipkin::Headers]
+      #
+      def headers
+        @headers ||= Gruf::Zipkin::Headers.new(@active_call)
+      end
+
+      ##
+      # @return [String]
+      #
+      def request_class
+        @request.class.to_s
+      end
+    end
+  end
+end

--- a/lib/gruf/zipkin/trace.rb
+++ b/lib/gruf/zipkin/trace.rb
@@ -1,0 +1,135 @@
+module Gruf
+  module Zipkin
+    ##
+    # Represents a trace through Gruf and gRPC
+    #
+    class Trace
+      attr_reader :method, :service_key
+
+      METADATA_KEYS = {
+        error: 'error',
+        grpc: {
+          method: 'grpc.method',
+          request_class: 'grpc.request_class',
+          error: 'grpc.error',
+          error_code: 'grpc.error_code',
+          error_class: 'grpc.error_class',
+          success: 'grpc.success',
+        }
+      }.freeze
+
+      ##
+      # @param [Gruf::Zipkin::Method] method
+      # @param [String|Symbol] service_key
+      # @param [Hash] options
+      #
+      def initialize(method, service_key, options = {})
+        @method = method
+        @service_key = service_key.to_s
+        @options = options
+      end
+
+      ##
+      # Trace the request
+      #
+      # @param [::Trace::Tracer] The tracing service to use
+      # @return [Object]
+      #
+      def trace!(tracer, &block)
+        raise ArgumentError, 'no block given' unless block_given?
+        result = nil
+
+        tracer.with_new_span(trace_id, component) do |span|
+          span.record(::Trace::Annotation::SERVER_RECV)
+          span.record_local_component(component)
+          span.record_tag(METADATA_KEYS[:grpc][:method], method.signature.classify)
+          span.record_tag(METADATA_KEYS[:grpc][:request_class], method.request_class)
+
+          begin
+            result = block.call(method.request, method.active_call)
+            span.record(::Trace::Annotation::SERVER_SEND)
+          rescue => e
+            if e.is_a?(::GRPC::BadStatus)
+              span.record_tag(METADATA_KEYS[:error], true)
+              span.record_tag(METADATA_KEYS[:grpc][:error], true)
+              span.record_tag(METADATA_KEYS[:grpc][:error_code], e.code.to_s)
+              span.record_tag(METADATA_KEYS[:grpc][:error_class], e.class.to_s)
+            end
+            span.record(::Trace::Annotation::SERVER_SEND)
+            tracer.end_span(span) # manually end here as the raise prevents this
+            raise # passthrough, we just want the annotations
+          end
+        end
+        result
+      end
+
+
+      ##
+      # Memoize build of a new trace_id based on propagation headers, or generator if
+      # no headers are present
+      # 
+      # @return [::Trace::TraceId]
+      #
+      def trace_id
+        unless @trace_id
+          tid = header_value(:trace_id)
+          span_id = header_value(:span_id)
+          # both trace ID and span ID are required for propagation
+          if !tid.to_s.empty? && !span_id.to_s.empty?
+            # we have a propagated trace, let's carry over the information
+            parent_id = header_value(:parent_span_id)
+            sampled = header_value(:sampled)
+            flags = header_value(:flags)
+            @trace_id = ::Trace::TraceId.new(tid, parent_id, span_id, sampled, flags)
+          else
+            # if trace_id/span_id are not present, generate a new trace
+            @trace_id = ::ZipkinTracer::TraceGenerator.new.next_trace_id
+          end
+        end
+        @trace_id
+      end
+
+      ##
+      # Delegator to headers object to get value of a B3 header
+      #
+      # @param [Symbol] key
+      # @return [String|NilClass]
+      #
+      def header_value(key)
+        @method.headers.value(key)
+      end
+
+      ##
+      # Returning whether or not this trace is sampled, which is based on either:the sample
+      # 1) The X-B3-Sampled header, if present
+      # 2) The sample rate set in the zipkin configuration
+      # ...in that order.
+      #
+      # @return [Boolean]
+      #
+      def sampled?
+        sampled = header_value(:sampled)
+        if sampled && sampled.to_s != ''
+          [1, '1', 'true', true].include?(sampled)
+        else
+          trace_id.sampled?
+        end
+      end
+
+      ##
+      # @return [String]
+      #
+      def component
+        "#{span_prefix}#{@service_key}.#{@method.signature}"
+      end
+
+      ##
+      # @return [String]
+      #
+      def span_prefix
+        prefix = @options.fetch(:span_prefix, '').to_s
+        prefix.empty? ? '' : "#{prefix}."
+      end
+    end
+  end
+end

--- a/lib/gruf/zipkin/version.rb
+++ b/lib/gruf/zipkin/version.rb
@@ -29,6 +29,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 module Gruf
   module Zipkin
-    VERSION = '0.9.1.pre'.freeze
+    VERSION = '0.10.0'.freeze
   end
 end

--- a/spec/gruf/zipkin/headers_spec.rb
+++ b/spec/gruf/zipkin/headers_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'securerandom'
+
+describe Gruf::Zipkin::Headers do
+  let(:active_call) { grpc_active_call(metadata: metadata) }
+  let(:metadata) { {} }
+  let(:headers) { described_class.new(active_call) }
+
+  describe '.value' do
+    let(:val) { SecureRandom.uuid }
+
+    described_class::ZIPKIN_KEYS.each do |name, keys|
+      context "when checking for the #{name} header value" do
+        subject { headers.value(name) }
+
+        keys.each do |key|
+          context "when the key #{key} is set" do
+            let(:metadata) { { key.to_s => val } }
+
+            it 'should return the value' do
+              expect(subject).to eq val
+            end
+          end
+
+          context "when the key #{key} is not set" do
+            let(:metadata) { { "#{key}_nope" => val } }
+
+            it 'should return nil' do
+              expect(subject).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/gruf/zipkin/hook_spec.rb
+++ b/spec/gruf/zipkin/hook_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Gruf::Zipkin::Hook do
+  let(:service) { ThingService.new }
+  let(:options) { {} }
+  let(:signature) { 'get_thing' }
+  let(:request) { grpc_request }
+  let(:active_call) { grpc_active_call }
+  let(:hook) { described_class.new(service, { zipkin: options.merge(sampled_as_boolean: false) }) }
+
+  before do
+    allow(::Trace::Endpoint).to receive(:local_endpoint).and_return(nil)
+  end
+
+  describe '.service_key' do
+    subject { hook.service_key }
+    it 'should be the translated service class name' do
+      expect(subject).to eq 'thing_service'
+    end
+  end
+
+  describe '.options' do
+    let(:options) { { abc: 'def' } }
+    subject { hook.options }
+
+    it 'should return zipkin options' do
+      expect(subject).to eq options.merge(sampled_as_boolean: false)
+    end
+  end
+
+  describe '.around' do
+    let(:trace) { grpc_trace }
+    let(:sampled) { true }
+    subject { hook.around(trace.method.signature, trace.method.request, trace.method.active_call) { true } }
+
+    before do
+      allow(hook).to receive(:build_trace).and_return(trace)
+      allow(trace).to receive(:sampled?).and_return(sampled)
+    end
+
+    context 'when the trace is sampled' do
+      it 'should trace the request' do
+        expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).with(trace.trace_id).and_call_original
+        expect(trace).to receive(:trace!)
+        subject
+      end
+    end
+
+    context 'when the trace is not sampled' do
+      let(:sampled) { false }
+      it 'should not trace the request' do
+        expect(ZipkinTracer::TraceContainer).to_not receive(:with_trace_id)
+        subject
+      end
+    end
+  end
+end

--- a/spec/gruf/zipkin/method_spec.rb
+++ b/spec/gruf/zipkin/method_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Gruf::Zipkin::Method do
+  let(:active_call) { grpc_active_call }
+  let(:signature) { 'get_thing' }
+  let(:request) { grpc_request }
+
+  let(:method) { described_class.new(active_call, signature, request) }
+
+  describe '.request_class' do
+    subject { method.request_class }
+    it 'should return the class name of the passed request' do
+      expect(subject).to eq 'ThingRequest'
+    end
+  end
+
+  describe '.headers' do
+    subject { method.headers }
+    it 'should return a headers object' do
+      expect(subject).to be_a(Gruf::Zipkin::Headers)
+    end
+  end
+end

--- a/spec/gruf/zipkin/trace_spec.rb
+++ b/spec/gruf/zipkin/trace_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+
+describe Gruf::Zipkin::Trace do
+  let(:metadata) { {} }
+  let(:method) { grpc_method(metadata: metadata) }
+  let(:options) { {} }
+  let(:trace) { described_class.new(method, 'thing_service', options)}
+  
+  describe '.trace_id' do
+    subject { trace.trace_id }
+
+    context 'with no headers' do
+      it 'should return a new trace id' do
+        expect_any_instance_of(::ZipkinTracer::TraceGenerator).to receive(:next_trace_id).and_call_original
+        expect(subject).to be_a(::Trace::TraceId)
+      end
+    end
+
+    context 'with the trace_id and span_id headers' do
+      let(:metadata) { {
+        'X-B3-SpanId' => rand(2**64),
+        'X-B3-TraceId' => rand(2**64),
+      } }
+
+      it 'should return a trace ID built from the headers' do
+        expect(subject).to be_a(::Trace::TraceId)
+        expect(subject.span_id.to_i).to eq ::Trace::SpanId.from_value(metadata['X-B3-SpanId']).to_i
+        expect(subject.trace_id.to_i).to eq ::Trace::SpanId.from_value(metadata['X-B3-TraceId']).to_i
+      end
+
+      context 'with the required and optional headers' do
+        let(:metadata) { {
+            'X-B3-SpanId' => rand(2**64),
+            'X-B3-TraceId' => rand(2**64),
+            'X-B3-ParentSpanId' => rand(2**64),
+            'X-B3-Sampled' => '1',
+            'X-B3-Flags' => '1',
+        } }
+        it 'should return a trace ID built from those headers' do
+          expect(subject).to be_a(::Trace::TraceId)
+          expect(subject.span_id.to_i).to eq ::Trace::SpanId.from_value(metadata['X-B3-SpanId']).to_i
+          expect(subject.trace_id.to_i).to eq ::Trace::SpanId.from_value(metadata['X-B3-TraceId']).to_i
+          expect(subject.parent_id.to_i).to eq ::Trace::SpanId.from_value(metadata['X-B3-ParentSpanId']).to_i
+          expect(subject.sampled).to eq metadata['X-B3-Sampled']
+          expect(subject.flags).to eq metadata['X-B3-Flags']
+        end
+      end
+    end
+
+    context 'with only the trace_id header' do
+      let(:metadata) { {
+          'X-B3-TraceId' => rand(2**64),
+      } }
+
+      it 'should ignore it and build a new span' do
+        expect_any_instance_of(::ZipkinTracer::TraceGenerator).to receive(:next_trace_id).and_call_original
+        expect(subject).to be_a(::Trace::TraceId)
+        expect(subject.trace_id.to_i).to_not eq ::Trace::SpanId.from_value(metadata['X-B3-TraceId']).to_i
+      end
+    end
+
+    context 'with only the span_id header' do
+      let(:metadata) { {
+          'X-B3-SpanId' => rand(2**64),
+      } }
+
+      it 'should ignore it and build a new span' do
+        expect_any_instance_of(::ZipkinTracer::TraceGenerator).to receive(:next_trace_id).and_call_original
+        expect(subject).to be_a(::Trace::TraceId)
+        expect(subject.trace_id.to_i).to_not eq ::Trace::SpanId.from_value(metadata['X-B3-SpanId']).to_i
+      end
+    end
+  end
+
+  describe '.sampled?' do
+    subject { trace.sampled? }
+
+    [1, '1', true, 'true'].each do |v|
+      context "when the X-B3-Sampled header is passed with value #{v}" do
+        let(:metadata) { {
+            'X-B3-Sampled' => v,
+        } }
+
+        it 'should return true' do
+          expect(subject).to be_truthy
+        end
+      end
+    end
+
+    [0, '0', false, 'false'].each do |v|
+      context "when the X-B3-Sampled header is passed with value #{v}" do
+        let(:metadata) { {
+            'X-B3-Sampled' => v,
+        } }
+
+        it 'should return false' do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+
+    context 'when the X-B3-Sampled header is an empty string' do
+      let(:expected_val) { rand(2) }
+      let(:metadata) { {
+          'X-B3-Sampled' => '',
+      } }
+
+      it 'should fallback to the sample rate' do
+        expect(trace.trace_id).to receive(:sampled?).and_return(expected_val)
+        expect(subject).to eq expected_val
+      end
+    end
+
+    context 'when the X-B3-Sampled header is not passed' do
+      let(:expected_val) { rand(2) }
+
+      it 'should fallback to the sample rate' do
+        expect(trace.trace_id).to receive(:sampled?).and_return(expected_val)
+        expect(subject).to eq expected_val
+      end
+    end
+  end
+
+  describe '.span_prefix' do
+    subject { trace.span_prefix }
+
+    context 'when a span prefix is passed' do
+      let(:options) { { span_prefix: 'abc' } }
+
+      it 'should append the prefix and a .' do
+        expect(subject).to eq 'abc.'
+      end
+    end
+
+    context 'when no span prefix is passed' do
+      it 'should return blank' do
+        expect(subject).to eq ''
+      end
+    end
+  end
+
+  describe '.component' do
+    subject { trace.component }
+
+    context 'with a span prefix' do
+      let(:options) { { span_prefix: 'abc' } }
+
+      it 'should return the service key and the method signature concatenated with a . and prefixed' do
+        expect(subject).to eq 'abc.thing_service.get_thing'
+      end
+    end
+
+    context 'with no span prefix' do
+      it 'should return the service key and the method signature concatenated with a .' do
+        expect(subject).to eq 'thing_service.get_thing'
+      end
+    end
+  end
+end

--- a/spec/gruf/zipkin/version_spec.rb
+++ b/spec/gruf/zipkin/version_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Gruf::Zipkin do
+  describe 'version' do
+    it 'should have a version' do
+      expect(Gruf::Zipkin::VERSION).to be_a(String)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,9 +27,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'gruf'
-require 'ffaker'
 require 'pry'
+require 'gruf'
+require 'gruf/zipkin'
 
 Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each {|f| require f }
 
@@ -43,4 +43,6 @@ RSpec.configure do |config|
     mocks.allow_message_expectations_on_nil = true
   end
   config.color = true
+
+  config.include Gruf::Zipkin::SpecHelpers
 end

--- a/spec/support/request.rb
+++ b/spec/support/request.rb
@@ -1,0 +1,30 @@
+
+class ThingRequest; end
+class ThingService; end
+
+module Gruf
+  module Zipkin
+    module SpecHelpers
+
+      def grpc_method(metadata: {}, signature: 'get_thing')
+        active_call = grpc_active_call(metadata: metadata)
+        signature = signature
+        request = grpc_request
+        ::Gruf::Zipkin::Method.new(active_call, signature, request)
+      end
+
+      def grpc_active_call(metadata: {}, output_metadata: {})
+        double(:active_call, metadata: metadata, output_metadata: output_metadata)
+      end
+
+      def grpc_trace(metadata: {}, service_key: 'thing_service', signature: 'get_thing', options: {})
+        method = grpc_method(metadata: metadata, signature: signature)
+        Gruf::Zipkin::Trace.new(method, service_key, options)
+      end
+
+      def grpc_request
+        ThingRequest.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
This gets the Gruf->Zipkin configuration fully working:
* Spans now properly record server recv/send annotations
* gRPC annotations for errors are now properly recording
* Failures in gruf service endpoints are now intercepted and error annotations are properly sent
* B3 propagation now works by checking the `GRPC::ActiveCall` metadata headers with support for headers initiating from H1 requests

Confirmed in a test rails service. Updated README for better installation instructions.

----

@bigcommerce/services 