### PR TITLE
ARCH-299: Handle case when tracer is not initialized upon trace request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for the gruf-zipkin gem.
 
+h3. 0.10.1
+
+- Handle case when tracer is not yet initialized before trace executes
+
 h3. 0.10.0
 
 - Initial public release

--- a/lib/gruf/zipkin/trace.rb
+++ b/lib/gruf/zipkin/trace.rb
@@ -37,6 +37,13 @@ module Gruf
       #
       def trace!(tracer, &block)
         raise ArgumentError, 'no block given' unless block_given?
+        # If for some reason we don't have a tracer, let's just proceed as normal
+        # and not cause the request to fail
+        unless tracer
+          Gruf.logger.warn "Failed to log trace for #{method.request_class}.#{method.signature.classify} because Tracer was not found!" if Gruf.logger
+          return block.call(method.request, method.active_call)
+        end
+
         result = nil
 
         tracer.with_new_span(trace_id, component) do |span|

--- a/lib/gruf/zipkin/version.rb
+++ b/lib/gruf/zipkin/version.rb
@@ -29,6 +29,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 module Gruf
   module Zipkin
-    VERSION = '0.10.0'.freeze
+    VERSION = '0.10.1'.freeze
   end
 end


### PR DESCRIPTION
We saw a situation in which the Tracer had not yet initialized before the gRPC request was handled, which caused the method call to fail due to a nil error; this wraps the trace in a guard clause to proceed without a trace should a tracer not exist.

----

@pedelman @bigcommerce/services 